### PR TITLE
Fix authStore user id retrieval

### DIFF
--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 
 // Initial state for the store
 const initialAuthState = {
@@ -47,6 +47,7 @@ export default {
     // For now, we'll keep it simple.
 
     accessUserId: () => {
-        return initialAuthState.user.id;
+        const state = get(authStore);
+        return state.user ? state.user.id : null;
     },
 };

--- a/frontend/src/store/socketStore.js
+++ b/frontend/src/store/socketStore.js
@@ -9,8 +9,13 @@ socket.on('connect', () => {
     console.log('Connected to server.');
     socketConnection.set(socket);
     isConnected.set(true);
-    const userId = `user_${authStore.accessUserId()}`;
-    socket.emit('joinRoom', userId);
+    const rawId = authStore.accessUserId();
+    if (rawId != null) {
+      const userId = `user_${rawId}`;
+      socket.emit('joinRoom', userId);
+    } else {
+      console.warn('Skipping joinRoom: no authenticated user');
+    }
 });
 
 socket.on('disconnect', () => {

--- a/frontend/src/store/socketStore.js
+++ b/frontend/src/store/socketStore.js
@@ -9,7 +9,7 @@ socket.on('connect', () => {
     console.log('Connected to server.');
     socketConnection.set(socket);
     isConnected.set(true);
-    const userId = `user_${authStore.accessUserId}`;
+    const userId = `user_${authStore.accessUserId()}`;
     socket.emit('joinRoom', userId);
 });
 


### PR DESCRIPTION
## Summary
- return the actual user id from authStore
- call accessUserId() when joining socket room

## Testing
- `npm run test-auth` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_684146da9c98832596925e495dd2d6e7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- User ID is now accurately retrieved based on the current logged-in user, ensuring correct user identification across the app.
	- Real-time features now dynamically use the latest user ID when connecting, improving reliability for socket-based actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->